### PR TITLE
Fixed ISML linter GitHub action

### DIFF
--- a/linters/ismllint.js
+++ b/linters/ismllint.js
@@ -6,6 +6,7 @@ const path = require("path");
 const process = require("process");
 const uuid4 = require("uuid/v4");
 const _flatMap = require("lodash/flatMap");
+const _replace = require("lodash/replace");
 
 function getAnnotations(annotationsData, annotationsPrefix) {
     return _flatMap(annotationsData, result => {


### PR DESCRIPTION
Added missing reference to `_replace` called in the linter code logic.