### PR TITLE
Upgraded package dependency to fix the security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "stylelint-scss": "^3.8.0",
     "uuid": "^3.3.2",
     "yargs": "^13.2.4",
-    "babel-eslint": "^10.0.3"
+    "babel-eslint": "^10.0.3",
+    "kind-of": ">=6.0.3"
   }
 }


### PR DESCRIPTION
Added minimum dependency as per the https://github.com/OSFGlobal/OSF-Linter/network/alert/package-lock.json/kind-of/open instructions

1 kind-of vulnerability found in package-lock.json 4 days ago
Remediation
Upgrade kind-of to version 6.0.3 or later. For example:

"dependencies": {
  "kind-of": ">=6.0.3"
}
or…
"devDependencies": {
  "kind-of": ">=6.0.3"
}
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2019-20149
moderate severity
Vulnerable versions: >= 6.0.0, < 6.0.3
Patched version: 6.0.3
ctorName in index.js in kind-of v6.0.0 - v6.0.2 allows external user input to overwrite certain internal attributes via a conflicting name, as demonstrated by 'constructor': {'name':'Symbol'}. Hence, a crafted payload can overwrite this builtin attribute to manipulate the type detection result.