### PR TITLE
Upgrade Isml linter

### DIFF
--- a/config/.ismllintrc.js
+++ b/config/.ismllintrc.js
@@ -17,6 +17,7 @@ module.exports = {
         "no-embedded-isml": {},
         "no-hardcode": {},
         "no-require-in-loop": {},
+        "enforce-security" : {},
         "one-element-per-line": {}
     }
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint": "^6.0.0",
     "fs-extra": "^8.0.1",
     "globby": "^9.2.0",
-    "isml-linter": "^5.26.6",
+    "isml-linter": "^5.27.0",
     "lodash": ">=4.17.19",
     "stylelint": "^10.1.0",
     "stylelint-config-standard": "^18.3.0",


### PR DESCRIPTION
- Introducing "[enforce-security](https://github.com/FabiowQuixada/isml-linter/blob/master/docs/rules/enforce-security.md)" rule, to prevent reverse tabnabbing;
- Fixed issue related to "eslint-to-isscript" in the main flow;
- Fixed and improved "indent" rule;
- Other minor fixes and improvements;